### PR TITLE
[Design, Feat] 조회 페이지 디자인 수정 및 인덱스 추가하기 페이지 구현

### DIFF
--- a/src/app/addIndex/page.tsx
+++ b/src/app/addIndex/page.tsx
@@ -83,9 +83,6 @@ export default function AddIndexPage() {
     }
   };
 
-  console.log(formData);
-  console.log(emotionData);
-
   return (
     <div className='relative flex flex-col items-center'>
       <Suspense fallback={null}>

--- a/src/app/read/page.tsx
+++ b/src/app/read/page.tsx
@@ -63,6 +63,10 @@ export default function ReadPage() {
     setShowDeleteModal(false);
   };
 
+  const handleClickAddIndex = (isbn: string) => {
+    router.push(`/addIndex?isbn=${isbn}`);
+  };
+
   return (
     <div className='relative'>
       <Suspense fallback={null}>
@@ -256,6 +260,7 @@ export default function ReadPage() {
           <button
             type='button'
             className='w-[172px] h-[46px] flex items-center justify-center bg-gray-700 mb-4 rounded-lg cursor-pointer'
+            onClick={() => handleClickAddIndex(book.isbn)}
           >
             <img
               src='/icons/plusIcon.svg'

--- a/src/app/read/page.tsx
+++ b/src/app/read/page.tsx
@@ -196,15 +196,12 @@ export default function ReadPage() {
                   <h2 className='font-sans font-semibold text-xl text-gray-900 mb-4'>
                     기록을 삭제하시겠어요?
                   </h2>
-                  {/* <p className='font-sans text-base text-gray-700 leading-[25px] mb-6'>
-                    벗어나면 수정 중인 내용은 삭제돼요
-                  </p> */}
                   <button
                     type='button'
                     className='w-[300px] h-[50px] bg-state-error rounded-lg font-sans font-medium text-base text-background-input mb-2'
                     onClick={handleClickDeleteBtn}
                   >
-                    확인
+                    삭제
                   </button>
                   <button
                     type='button'

--- a/src/app/read/page.tsx
+++ b/src/app/read/page.tsx
@@ -121,13 +121,17 @@ export default function ReadPage() {
           >
             <div className='flex justify-between'>
               <div className='flex items-center'>
-                {item.page ? (
-                  <p className='w-[63px] h-[30px] bg-gray-200 rounded-sm font-sans font-medium text-xs text-gray-700 flex justify-center items-center mr-4'>
-                    {item.page} P
-                  </p>
-                ) : (
-                  ''
-                )}
+                {item.status === 'READING' ? (
+                  item.page ? (
+                    <p className='h-[30px] bg-gray-200 rounded-sm font-sans font-medium text-xs text-gray-700 flex justify-center items-center mr-4 px-4 py-2'>
+                      {item.page} P
+                    </p>
+                  ) : (
+                    <p className='h-[30px] bg-gray-200 rounded-sm font-sans font-medium text-xs text-gray-700 flex justify-center items-center mr-4 px-4 py-2'>
+                      페이지 없음
+                    </p>
+                  )
+                ) : null}
                 <p className='font-sans text-xs text-gray-500'>{item.createdAt.slice(0, 10)}</p>
               </div>
               <div className='flex'>

--- a/src/app/report/page.tsx
+++ b/src/app/report/page.tsx
@@ -4,7 +4,7 @@ import MyBookHistory from '@/components/reportPage/myBookHistory';
 
 export default function ReportPage() {
   return (
-    <>
+    <div className='flex flex-col items-center'>
       <Header />
       <div className='w-[1030px] flex flex-col mx-auto pb-14'>
         <Calendar />
@@ -18,6 +18,6 @@ export default function ReportPage() {
         </div>
         <MyBookHistory />
       </div>
-    </>
+    </div>
   );
 }

--- a/src/app/update/page.tsx
+++ b/src/app/update/page.tsx
@@ -154,7 +154,7 @@ export default function UpdatePage() {
                 아직 수정이 완료 되지 않았어요
               </h2>
               <p className='font-sans text-base text-gray-700 leading-[25px] mb-6'>
-                벗어나면 수정 중인 내용은 삭제돼요
+                페이지를 벗어나면 수정한 내용은 삭제돼요
               </p>
               <button
                 type='button'
@@ -171,7 +171,7 @@ export default function UpdatePage() {
                 className='w-[300px] h-[50px] bg-gray-200 rounded-lg font-sans text-base text-gray-500'
                 onClick={() => setShowGotoBackModal(false)}
               >
-                계속 기록하기
+                계속 수정하기
               </button>
             </div>
           </div>

--- a/src/app/update/page.tsx
+++ b/src/app/update/page.tsx
@@ -123,7 +123,7 @@ export default function UpdatePage() {
   };
 
   return (
-    <div className='relative'>
+    <div className='relative flex flex-col items-center'>
       <Suspense fallback={null}>
         <UpdatePageContent
           setFormData={setFormData}
@@ -131,51 +131,53 @@ export default function UpdatePage() {
         />
       </Suspense>
       <div className='fixed w-full h-[90px] px-[205px] py-5 flex justify-between border-b-2 bg-background border-b-gray-200 z-10'>
-        <button
-          type='button'
-          onClick={() => setShowGotoBackModal(true)}
-        >
-          <img
-            src='/icons/arrowLeft.svg'
-            alt='뒤로가기 아이콘'
-          />
-        </button>
-        <button
-          type='submit'
-          className='w-[190px] h-[50px] rounded-lg font-sans font-medium bg-primary text-background-input cursor-pointer'
-          onClick={handleClickUpdateBtn}
-        >
-          수정하기
-        </button>
-        {showGotoBackModal && (
-          <div className='fixed inset-0 flex justify-center items-center bg-black/50 z-30'>
-            <div className='w-[413px] h-[288px] flex flex-col items-center justify-center bg-background-input rounded-2xl px-14 py-12'>
-              <h2 className='font-sans font-semibold text-xl text-gray-900 mb-4'>
-                아직 수정이 완료 되지 않았어요
-              </h2>
-              <p className='font-sans text-base text-gray-700 leading-[25px] mb-6'>
-                페이지를 벗어나면 수정한 내용은 삭제돼요
-              </p>
-              <button
-                type='button'
-                className='w-[300px] h-[50px] bg-state-error rounded-lg font-sans font-medium text-base text-background-input mb-2'
-                onClick={() => {
-                  setShowGotoBackModal(false);
-                  router.back();
-                }}
-              >
-                확인
-              </button>
-              <button
-                type='button'
-                className='w-[300px] h-[50px] bg-gray-200 rounded-lg font-sans text-base text-gray-500'
-                onClick={() => setShowGotoBackModal(false)}
-              >
-                계속 수정하기
-              </button>
+        <div className='max-w-[1030px] w-full mx-auto flex justify-between px-8'>
+          <button
+            type='button'
+            onClick={() => setShowGotoBackModal(true)}
+          >
+            <img
+              src='/icons/arrowLeft.svg'
+              alt='뒤로가기 아이콘'
+            />
+          </button>
+          <button
+            type='submit'
+            className='w-[190px] h-[50px] rounded-lg font-sans font-medium bg-primary text-background-input cursor-pointer'
+            onClick={handleClickUpdateBtn}
+          >
+            수정하기
+          </button>
+          {showGotoBackModal && (
+            <div className='fixed inset-0 flex justify-center items-center bg-black/50 z-30'>
+              <div className='w-[413px] h-[288px] flex flex-col items-center justify-center bg-background-input rounded-2xl px-14 py-12'>
+                <h2 className='font-sans font-semibold text-xl text-gray-900 mb-4'>
+                  아직 수정이 완료 되지 않았어요
+                </h2>
+                <p className='font-sans text-base text-gray-700 leading-[25px] mb-6'>
+                  페이지를 벗어나면 수정한 내용은 삭제돼요
+                </p>
+                <button
+                  type='button'
+                  className='w-[300px] h-[50px] bg-state-error rounded-lg font-sans font-medium text-base text-background-input mb-2'
+                  onClick={() => {
+                    setShowGotoBackModal(false);
+                    router.back();
+                  }}
+                >
+                  확인
+                </button>
+                <button
+                  type='button'
+                  className='w-[300px] h-[50px] bg-gray-200 rounded-lg font-sans text-base text-gray-500'
+                  onClick={() => setShowGotoBackModal(false)}
+                >
+                  계속 수정하기
+                </button>
+              </div>
             </div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
       <div className='w-[1030px] mx-auto mb-14 pt-[90px]'>
         <div className='w-full bg-background-input rounded-3xl mt-[68px] pb-14 px-[105px]'>

--- a/src/app/write/page.tsx
+++ b/src/app/write/page.tsx
@@ -114,64 +114,66 @@ export default function WritePage() {
   };
 
   return (
-    <div className='relative'>
+    <div className='relative flex flex-col items-center'>
       <Suspense fallback={null}>
         <WritePageContent
           setSelectedBook={setSelectedBook}
           setFormData={setFormData}
         />
       </Suspense>
-      <div className='fixed w-full h-[90px] px-[205px] py-5 flex justify-between border-b-2 bg-background border-b-gray-200 z-10'>
-        <button
-          type='button'
-          onClick={() => setShowGotoBackModal(true)}
-        >
-          <img
-            src='/icons/arrowLeft.svg'
-            alt='뒤로가기 아이콘'
-          />
-        </button>
-        <button
-          type='submit'
-          className={`w-[190px] h-[50px] rounded-lg font-sans font-medium ${
-            isSubmitEnabled
-              ? 'bg-primary text-background-input cursor-pointer'
-              : 'bg-gray-300 text-gray-500 cursor-not-allowed'
-          }`}
-          disabled={!isSubmitEnabled}
-          onClick={handleClickSubmitBtn}
-        >
-          등록하기
-        </button>
-        {showGotoBackModal && (
-          <div className='fixed inset-0 flex justify-center items-center bg-black/50 z-30'>
-            <div className='w-[413px] h-[288px] flex flex-col items-center justify-center bg-background-input rounded-2xl px-14 py-12'>
-              <h2 className='font-sans font-semibold text-xl text-gray-900 mb-4'>
-                아직 작성이 완료 되지 않았어요
-              </h2>
-              <p className='font-sans text-base text-gray-700 leading-[25px] mb-6'>
-                벗어나면 작성 중인 내용은 삭제돼요
-              </p>
-              <button
-                type='button'
-                className='w-[300px] h-[50px] bg-state-error rounded-lg font-sans font-medium text-base text-background-input mb-2'
-                onClick={() => {
-                  setShowGotoBackModal(false);
-                  router.back();
-                }}
-              >
-                확인
-              </button>
-              <button
-                type='button'
-                className='w-[300px] h-[50px] bg-gray-200 rounded-lg font-sans text-base text-gray-500'
-                onClick={() => setShowGotoBackModal(false)}
-              >
-                계속 기록하기
-              </button>
+      <div className='fixed w-full h-[90px] py-5 flex justify-between border-b-2 bg-background border-b-gray-200 z-10'>
+        <div className='max-w-[1030px] w-full mx-auto flex justify-between px-8'>
+          <button
+            type='button'
+            onClick={() => setShowGotoBackModal(true)}
+          >
+            <img
+              src='/icons/arrowLeft.svg'
+              alt='뒤로가기 아이콘'
+            />
+          </button>
+          <button
+            type='submit'
+            className={`w-[190px] h-[50px] rounded-lg font-sans font-medium ${
+              isSubmitEnabled
+                ? 'bg-primary text-background-input cursor-pointer'
+                : 'bg-gray-300 text-gray-500 cursor-not-allowed'
+            }`}
+            disabled={!isSubmitEnabled}
+            onClick={handleClickSubmitBtn}
+          >
+            등록하기
+          </button>
+          {showGotoBackModal && (
+            <div className='fixed inset-0 flex justify-center items-center bg-black/50 z-30'>
+              <div className='w-[413px] h-[288px] flex flex-col items-center justify-center bg-background-input rounded-2xl px-14 py-12'>
+                <h2 className='font-sans font-semibold text-xl text-gray-900 mb-4'>
+                  아직 작성이 완료 되지 않았어요
+                </h2>
+                <p className='font-sans text-base text-gray-700 leading-[25px] mb-6'>
+                  벗어나면 작성 중인 내용은 삭제돼요
+                </p>
+                <button
+                  type='button'
+                  className='w-[300px] h-[50px] bg-state-error rounded-lg font-sans font-medium text-base text-background-input mb-2'
+                  onClick={() => {
+                    setShowGotoBackModal(false);
+                    router.back();
+                  }}
+                >
+                  확인
+                </button>
+                <button
+                  type='button'
+                  className='w-[300px] h-[50px] bg-gray-200 rounded-lg font-sans text-base text-gray-500'
+                  onClick={() => setShowGotoBackModal(false)}
+                >
+                  계속 기록하기
+                </button>
+              </div>
             </div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
       <div className='w-[1030px] mx-auto mb-14 pt-[90px]'>
         {/* 기록할 책 선택하기 */}

--- a/src/components/detail/detailPage.tsx
+++ b/src/components/detail/detailPage.tsx
@@ -46,7 +46,7 @@ export default function DetailPage({ isbn }: DetailPageProps) {
   };
 
   return (
-    <>
+    <div className='flex flex-col items-center'>
       <Header />
       <div className='relative flex justify-center items-center'>
         <div className='w-[1030px] max-w-full flex flex-col gap-14 pb-14 mt-[125px]'>
@@ -140,6 +140,6 @@ export default function DetailPage({ isbn }: DetailPageProps) {
           </div>
         )}
       </div>
-    </>
+    </div>
   );
 }

--- a/src/components/mainPage/mainPage.tsx
+++ b/src/components/mainPage/mainPage.tsx
@@ -41,7 +41,7 @@ export default function MainPage() {
   };
 
   return (
-    <div className='relative'>
+    <div className='relative flex flex-col items-center'>
       <Header />
       <div className='w-[1030px] flex flex-col mx-auto'>
         <HeroSection />

--- a/src/components/search/resultSearchPage.tsx
+++ b/src/components/search/resultSearchPage.tsx
@@ -37,7 +37,7 @@ export default function ResultSearchPage({ keyword, type }: { keyword: string; t
   const rawBooks = data?.pages.flatMap((page) => page.books || []) || [];
 
   return (
-    <>
+    <div className='flex flex-col items-center'>
       <Header />
       <div className='pt-6 pb-6 max-w-[1030px] mx-auto'>
         <div className='flex flex-col mt-[100px]'>
@@ -181,6 +181,6 @@ export default function ResultSearchPage({ keyword, type }: { keyword: string; t
           <div ref={loadMoreRef} />
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/hooks/read/useDeleteRecords.ts
+++ b/src/hooks/read/useDeleteRecords.ts
@@ -1,5 +1,6 @@
 import { deleteFinishedRecord, deleteReadingRecord } from '@/apis/book/bookApi';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
 
 type DeleteParams =
   | { status: 'READING'; recordId: number }
@@ -7,6 +8,8 @@ type DeleteParams =
 
 const useDeleteRecords = () => {
   const queryClient = useQueryClient();
+  const router = useRouter();
+
   return useMutation({
     mutationFn: (params: DeleteParams) => {
       if (params.status === 'READING') {
@@ -14,8 +17,13 @@ const useDeleteRecords = () => {
       }
       return deleteFinishedRecord(params.bookshelfId);
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['allRecords'] });
+    onSuccess: (_, variables) => {
+      if (variables.status === 'READING') {
+        queryClient.invalidateQueries({ queryKey: ['allRecords'] });
+      }
+      if (variables.status === 'FINISHED') {
+        router.push('/');
+      }
     },
   });
 };


### PR DESCRIPTION
## 🛠️ 과제 요약

- 조회 페이지 디자인 수정 및 인덱스 추가하기 페이지 구현

## 📝 요구 사항과 구현 내용

- 조회 페이지에서 글카드에 페이지 없음 표시
- 팝업 디자인에 맞춰 수정
- 인덱스 페이지 마크업
- 인덱스 페이지 기능 및 api 연동

## ✅ 피드백 반영사항

- 브라우저 축소 시, 헤더가 가운데 정렬 안되길래 전체적으로 수정했습니다

## 🔗 연관된 이슈

- close #42 

